### PR TITLE
feat: adds ability to specify alternate options for select widget

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -130,6 +130,7 @@ class EditorControl extends React.Component {
       collection,
       config,
       field,
+      entry,
       fieldsMetaData,
       fieldsErrors,
       mediaPaths,
@@ -226,6 +227,7 @@ class EditorControl extends React.Component {
               field={field}
               uniqueFieldId={this.uniqueFieldId}
               value={value}
+              entry={entry}
               mediaPaths={mediaPaths}
               metadata={metadata}
               onChange={(newValue, newMetadata) => onChange(fieldName, newValue, newMetadata)}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -257,6 +257,7 @@ export default class Widget extends Component {
       controlRef,
       isEditorComponent,
       isNewEditorComponent,
+      entry,
       t,
     } = this.props;
     return React.createElement(controlComponent, {
@@ -301,6 +302,7 @@ export default class Widget extends Component {
       isNewEditorComponent,
       fieldsErrors,
       controlRef,
+      entry,
       t,
     });
   }

--- a/packages/netlify-cms-widget-select/src/SelectControl.js
+++ b/packages/netlify-cms-widget-select/src/SelectControl.js
@@ -111,9 +111,31 @@ export default class SelectControl extends React.Component {
     }
   }
 
+  getFieldOptions = (options) => {
+    const secondaryOptions = this.props.field.get('secondaryOptions');
+    secondaryOptions?.forEach(p => {
+      const fieldValue = this.props.entry.getIn(['data', p.get('fieldName')]);
+      const comparisonValue = p.get('value');
+      if (!!fieldValue && !List.isList(fieldValue)) {
+        const operators = {
+          'eq': (a, b) => a === b,
+          'lt': (a , b) => a < b,
+          'lteq': (a , b) => a <= b,
+          'gt': (a, b) => a > b,
+          'gteq': (a, b) => a >= b,
+        };
+
+        if (operators[p.get('op')](fieldValue, comparisonValue)) {
+          options = p.get('options');
+        }
+      }
+    });
+    return options;
+  };
+
   render() {
     const { field, value, forID, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
-    const fieldOptions = field.get('options');
+    const fieldOptions = this.getFieldOptions(field.get('options'));
     const isMultiple = field.get('multiple', false);
     const isClearable = !field.get('required', true) || isMultiple;
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Enables ability to specify alternate options for a select control based on the value of another field in the entry.

In your collection, where you specify the config for a select widget, you can now specify a secondaryOptions field, e.g.:
```
          {
            label: 'Locale',
            name: 'locale',
            widget: 'select',
            options: ['en', 'es'],
            default: ['en'],
          },
          {
            label: 'My Select',
            name: 'myselect',
            widget: 'select',
            options: defaultOptions,
            required: false,
            secondaryOptions: [{fieldName: 'locale', op: 'eq', value: 'es', options: myOtherOptions}],
          }
```

Valid options for op are:
```
eq
lt
lteq
gt
gteq
```

When the select with secondary options gains focus, the condition will be tested to see if it matches. For e.g. when 'myselect' above gains focus, if `locale === es` is true, then the `myOtherOptions` will be displayed instead of the `defaultOptions`.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
The need for alternate options of a select control based on other values of the entry, for e.g. language, theme etc.
